### PR TITLE
Draft PR: Fetch Exchange Rates

### DIFF
--- a/config.sample.json
+++ b/config.sample.json
@@ -1,56 +1,45 @@
 {
-    "BCH": {
-        "address": "",
-        "uriScheme": "bitcoincash:",
-        "amountParam": "?amount=",
-        "rateEndpoint": "https://api.coincap.io/v2/assets/bitcoin-cash"
-    },
-    "BTC": {
-        "address": "",
-        "uriScheme": "bitcoin:",
-        "amountParam": "?amount=",
-        "rateEndpoint": "https://api.coincap.io/v2/assets/bitcoin"
-    },
-    "DOGE": {
-        "address": "",
-        "uriScheme": "dogecoin:",
-        "amountParam": "?amount=",
-        "rateEndpoint": "https://api.coincap.io/v2/assets/dogecoin"
-    },
-    "ETH": {
-        "address": "",
-        "uriScheme": "ethereum:",
-        "amountParam": "?amount=",
-        "rateEndpoint": "https://api.coincap.io/v2/assets/ethereum"
-    },
-    "FIO": {
-        "address": "",
-        "uriScheme": "fio:",
-        "amountParam": "?amount=",
-        "rateEndpoint": "https://api.coincap.io/v2/assets/fio-protocol"
-    },
-    "LTC": {
-        "address": "",
-        "uriScheme": "litecoin:",
-        "amountParam": "?amount=",
-        "rateEndpoint": "https://api.coincap.io/v2/assets/litecoin"
-    },
-    "XLM": {
-        "address": "",
-        "uriScheme": "web+stellar:pay?destination=",
-        "amountParam": "&amount=",
-        "rateEndpoint": "https://api.coincap.io/v2/assets/stellar"
-    },
-    "XMR": {
-        "address": "",
-        "uriScheme": "monero:",
-        "amountParam": "?amount=",
-        "rateEndpoint": "https://api.coincap.io/v2/assets/monero"
-    },
-    "XRP": {
-        "address": "",
-        "uriScheme": "ripple:",
-        "amountParam": "?amount=",
-        "rateEndpoint": "https://api.coincap.io/v2/assets/xrp"
+    "coinCapUri": "https://api.coincap.io/v2/assets/",
+    "currencies": {
+        "BCH": {
+            "address": "",
+            "currencyName": "bitcoincash",
+            "coinCapCurrencyName": "bitcoin-cash"
+        },
+        "BTC": {
+            "address": "",
+            "currencyName": "bitcoin",
+            "coinCapCurrencyName": "bitcoin"
+        },
+        "DOGE": {
+            "address": "",
+            "currencyName": "dogecoin",
+            "coinCapCurrencyName": "dogecoin"
+        },
+        "ETH": {
+            "address": "",
+            "currencyName": "ethereum",
+            "coinCapCurrencyName": "ethereum"
+        },
+        "FIO": {
+            "address": "",
+            "currencyName": "fio",
+            "coinCapCurrencyName": "fio-protocol"
+        },
+        "LTC": {
+            "address": "",
+            "currencyName": "litecoin",
+            "coinCapCurrencyName": "litecoin"
+        },
+        "XMR": {
+            "address": "",
+            "currencyName": "monero",
+            "coinCapCurrencyName": "monero"
+        },
+        "XRP": {
+            "address": "",
+            "currencyName": "ripple",
+            "coinCapCurrencyName": "xrp"
+        }
     }
 }

--- a/src/exchangeRate.ts
+++ b/src/exchangeRate.ts
@@ -1,0 +1,26 @@
+import config from '../config.json'
+
+export interface CurrencyOption {
+  address: string
+  currencyName: string
+  coinCapCurrencyName: string
+}
+
+export const currencies: { [key: string]: CurrencyOption } = config.currencies
+const uri: string = config.coinCapUri
+
+export const fetchExchangeRates = async (): Promise<{
+  [key: string]: number
+}> => {
+  // Create an arry of promises
+  const promisesArr = Object.keys(currencies).map(async currencyCode => {
+    const currencyData = currencies[currencyCode]
+    const response = await fetch(uri + currencyData.coinCapCurrencyName)
+    const { data } = await response.json()
+    return { [currencyCode]: 1 / data.priceUsd }
+  })
+
+  // Resolve array of promises for exchange rates
+  const rates = await Promise.all(promisesArr)
+  return rates.reduce((result, rate) => ({ ...result, ...rate }), {})
+}


### PR DESCRIPTION
Questions on potential fixes for the `Allen/fetch exchange rates1` PR:

1. For `exchangeRate.ts`, we talked about adding a `try..catch` to wrap around the await. Instead of having the `catch` inside of the `fetchExchangeRates` function, I have it in `MainScene.tsx` where `fetchExchangeRates` is called (line 23 of `MainScene`). Is this an appropriate alternative?
2. For `MainScene.tsx`, we walked through how to call the function from `exchangeRate.ts` and where to put the `setInterval` method. Some of the documentation I saw online suggested `setTimeout` might be more appropriate. Is how I have it set up in lines 19-26 an acceptable alternative? (The original code can be found in lines 35-39 for reference)